### PR TITLE
refactor: use generic handlers

### DIFF
--- a/core/handlers.go
+++ b/core/handlers.go
@@ -1,0 +1,68 @@
+package core
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+)
+
+// Create : Generic function to perform a POST request to Nautobot.
+func Create[T any, R any](c *Client, uri string, body R) (*T, error) {
+	var resp T
+
+	req, err := c.Request(http.MethodPost, uri, body, nil)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.UnmarshalDo(req, &resp); err != nil {
+		return nil, fmt.Errorf("%s Create.error.UnmarshalDo(%w)", uri, err)
+	}
+	return &resp, nil
+}
+
+// Delete : Generic function to perform a DELETE request to Nautobot.
+func Delete(c *Client, uri string, id uuid.UUID) error {
+	if id == uuid.Nil {
+		return fmt.Errorf("%s Delete.error.ID(ID is missing or nil)", uri)
+	}
+	req, err := c.Request(http.MethodDelete, fmt.Sprintf("%s%s/", uri, id), nil, nil)
+	if err != nil {
+		return err
+	}
+	return c.UnmarshalDo(req, nil)
+}
+
+// Get : Generic function to perform a GET request to Nautobot for a single object.
+func Get[T any](c *Client, uri string, id uuid.UUID) (*T, error) {
+	if id == uuid.Nil {
+		return nil, fmt.Errorf("%s Get.error.ID(ID is missing or nil)", uri)
+	}
+
+	req, err := c.Request(http.MethodGet, fmt.Sprintf("%s%s/", uri, id), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	var resp T
+	if err := c.UnmarshalDo(req, &resp); err != nil {
+		return nil, fmt.Errorf("%s Get.error.UnmarshalDo(%w)", uri, err)
+	}
+	return &resp, nil
+}
+
+// Update : Generic function to perform a PATCH request to Nautobot.
+func Update[T any](c *Client, uri string, id uuid.UUID, patch map[string]any) (*T, error) {
+	var resp T
+	if id == uuid.Nil {
+		return nil, fmt.Errorf("%s Update.error.ID(ID is missing or nil)", uri)
+	}
+
+	req, err := c.Request(http.MethodPatch, fmt.Sprintf("%s%s/", uri, id), patch, nil)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.UnmarshalDo(req, &resp); err != nil {
+		return nil, fmt.Errorf("%s Update.error.UnmarshalDo(%w)", uri, err)
+	}
+	return &resp, nil
+}

--- a/extras/role.go
+++ b/extras/role.go
@@ -1,14 +1,15 @@
 package extras
 
 import (
-	"errors"
-	"fmt"
-	"net/http"
 	"net/url"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/josh-silvas/gonautobot/core"
+)
+
+const (
+	extrasEndpointRole = "extras/roles/"
 )
 
 type (
@@ -43,17 +44,7 @@ type (
 
 // RoleGet : Get a Role by UUID identifier.
 func (c *Client) RoleGet(id uuid.UUID) (*Role, error) {
-	if id == uuid.Nil {
-		return nil, errors.New("RoleGet.error.ID(ID is missing or nil)")
-	}
-	req, err := c.Request(http.MethodGet, fmt.Sprintf("extras/roles/%s/", id), nil, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	ret := new(Role)
-	err = c.UnmarshalDo(req, ret)
-	return ret, err
+	return core.Get[Role](c.Client, extrasEndpointRole, id)
 }
 
 // RoleFilter : Get a list of Roles based on query parameters.
@@ -69,43 +60,16 @@ func (c *Client) RoleAll() ([]Role, error) {
 }
 
 // RoleCreate : Generate a new Role record in Nautobot.
-func (c *Client) RoleCreate(obj NewRole) (Role, error) {
-	var r Role
-	req, err := c.Request(http.MethodPost, "extras/roles/", obj, nil)
-	if err != nil {
-		return r, err
-	}
-
-	if err := c.UnmarshalDo(req, &r); err != nil {
-		return r, fmt.Errorf("RoleCreate.error.UnmarshalDo(%w)", err)
-	}
-	return r, nil
+func (c *Client) RoleCreate(obj NewRole) (*Role, error) {
+	return core.Create[Role, NewRole](c.Client, extrasEndpointRole, obj)
 }
 
 // RoleDelete : Delete a Role by UUID identifier.
 func (c *Client) RoleDelete(id uuid.UUID) error {
-	if id == uuid.Nil {
-		return errors.New("RoleDelete.error.ID(ID is missing or nil)")
-	}
-	req, err := c.Request(http.MethodDelete, fmt.Sprintf("extras/roles/%s/", id), nil, nil)
-	if err != nil {
-		return err
-	}
-	return c.UnmarshalDo(req, nil)
+	return core.Delete(c.Client, extrasEndpointRole, id)
 }
 
 // RoleUpdate : Update an existing Role record in Nautobot.
-func (c *Client) RoleUpdate(id uuid.UUID, patch map[string]any) (Role, error) {
-	var r Role
-	if id == uuid.Nil {
-		return r, errors.New("RoleUpdate.error.ID(ID is missing or nil)")
-	}
-	req, err := c.Request(http.MethodPatch, fmt.Sprintf("extras/roles/%s/", id), patch, nil)
-	if err != nil {
-		return r, err
-	}
-	if err := c.UnmarshalDo(req, &r); err != nil {
-		return r, fmt.Errorf("RoleUpdate.error.UnmarshalDo(%w)", err)
-	}
-	return r, nil
+func (c *Client) RoleUpdate(id uuid.UUID, patch map[string]any) (*Role, error) {
+	return core.Update[Role](c.Client, extrasEndpointRole, id, patch)
 }

--- a/extras/status.go
+++ b/extras/status.go
@@ -1,14 +1,15 @@
 package extras
 
 import (
-	"errors"
-	"fmt"
-	"net/http"
 	"net/url"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/josh-silvas/gonautobot/core"
+)
+
+const (
+	extrasEndpointStatus = "extras/statuses/"
 )
 
 type (
@@ -41,17 +42,7 @@ type (
 
 // StatusGet : Go function to process requests for the endpoint: /api/extras/statuses/:id/
 func (c *Client) StatusGet(id uuid.UUID) (*Status, error) {
-	if id == uuid.Nil {
-		return nil, errors.New("StatusGet.error.ID(ID is missing or nil)")
-	}
-	req, err := c.Request(http.MethodGet, fmt.Sprintf("extras/statuses/%s/", id), nil, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	ret := new(Status)
-	err = c.UnmarshalDo(req, ret)
-	return ret, err
+	return core.Get[Status](c.Client, extrasEndpointStatus, id)
 }
 
 // StatusFilter : Go function to process requests for the endpoint: /api/extras/statuses/
@@ -67,43 +58,16 @@ func (c *Client) StatusAll() ([]Status, error) {
 }
 
 // StatusCreate : Generate a new Status record in Nautobot.
-func (c *Client) StatusCreate(obj NewStatus) (Status, error) {
-	var r Status
-	req, err := c.Request(http.MethodPost, "extras/statuses/", obj, nil)
-	if err != nil {
-		return r, err
-	}
-
-	if err := c.UnmarshalDo(req, &r); err != nil {
-		return r, fmt.Errorf("StatusCreate.error.UnmarshalDo(%w)", err)
-	}
-	return r, nil
+func (c *Client) StatusCreate(obj NewStatus) (*Status, error) {
+	return core.Create[Status, NewStatus](c.Client, extrasEndpointStatus, obj)
 }
 
 // StatusDelete : Delete a Status by UUID identifier.
 func (c *Client) StatusDelete(id uuid.UUID) error {
-	if id == uuid.Nil {
-		return errors.New("StatusDelete.error.ID(ID is missing or nil)")
-	}
-	req, err := c.Request(http.MethodDelete, fmt.Sprintf("extras/statuses/%s/", id), nil, nil)
-	if err != nil {
-		return err
-	}
-	return c.UnmarshalDo(req, nil)
+	return core.Delete(c.Client, extrasEndpointStatus, id)
 }
 
 // StatusUpdate : Update an existing Status record in Nautobot.
-func (c *Client) StatusUpdate(id uuid.UUID, patch map[string]any) (Status, error) {
-	var r Status
-	if id == uuid.Nil {
-		return r, errors.New("StatusUpdate.error.ID(ID is missing or nil)")
-	}
-	req, err := c.Request(http.MethodPatch, fmt.Sprintf("extras/statuses/%s/", id), patch, nil)
-	if err != nil {
-		return r, err
-	}
-	if err := c.UnmarshalDo(req, &r); err != nil {
-		return r, fmt.Errorf("StatusUpdate.error.UnmarshalDo(%w)", err)
-	}
-	return r, nil
+func (c *Client) StatusUpdate(id uuid.UUID, patch map[string]any) (*Status, error) {
+	return core.Update[Status](c.Client, extrasEndpointStatus, id, patch)
 }


### PR DESCRIPTION
hey, since all the endpoint handlers are pretty much the same, what do you think about this refactor to use generics? It should reduce total lines and redundancy quite a bit.

If you like it, I'll update the other existing handlers before merging.